### PR TITLE
Add GIL contention metrics

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - python-graphviz==0.20.1 
   - beautifulsoup4==4.11.1
   - matplotlib==3.6.2
+  - gilknocker==0.4.1


### PR DESCRIPTION
@dchudz and I were looking at a cluster during the tutorial session today and wanted to look at GIL contention metrics. This PR add `gilknocker` so we get those metrics. 